### PR TITLE
byte

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -36,10 +36,14 @@ jobs:
           echo "env" ; env
           echo "pwd" ; pwd
           echo "ls -la" ; ls -la
-      - name: "make-usan"
-        run:  |
-          make clean
-          make CLANG_USAN=1
+      #- name: "make-fuzzer"
+      #  run:  |
+      #    make clean
+      #    make CLANG_FUZZER=1
+      #- name: "make-usan"
+      #  run:  |
+      #    make clean
+      #    make CLANG_USAN=1
       # - name: "make-asan"
       #   run:  |
       #     make clean

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,15 @@ ifeq ($(CLANG_MSAN),1)
 endif
 
 #
+# Fuzzing
+#
+
+ifeq ($(CLANG_FUZZER),1)
+	CFLAGS+=-fsanitize=address,fuzzer -DCLANG_FUZZER=1
+	CFLAGS+=-fno-omit-frame-pointer # For nicer stack traces
+endif
+
+#
 # Make
 #
 

--- a/main.c
+++ b/main.c
@@ -1,19 +1,42 @@
 #include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+
+int trigger_usan(int argc)
+{
+   int k = 0x7fffffff;
+   k += argc;
+}
+
+void trigger_asan()
+{
+   int array[1];
+   int y = array[1];
+}
+
+#ifdef CLANG_FUZZER
+   // This is the main entry point for our fuzzer (the TARGET function)
+   // Add extern "C" if compiled as C++
+   int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+      printf("%d\n", size);
+      if (size > 0 && data[0] == 'n') {
+         if (size > 1 && data[1] == 'o') {
+            if (size > 2 && data[2] == 'm') {
+               __builtin_trap();
+            }
+         }
+      }
+      return 0;
+   }
+
+#else // Only declare and define main if we aren't fuzzing
 
 int main(int argc, char **argv) {
 
-   /*
-   // Trigger undefined behaviour sanitizer
-   int k = 0x7fffffff;
-   k += argc;
-   */
-
-   /*
-   // Trigger address sanitizer (also memory sanitizer)
-   int array[1];
-   int y = array[1];
-   */
+   // trigger_usan(argc)
+   // trigger_asan()
 
    printf("nom\n");
    return 0;
 }
+#endif


### PR DESCRIPTION
Adds workflow job `make-fuzzer` that is disabled by default.

This calls `make CLANG_FUZZER=1` and builds `bytey` as a library with no `main` but instead a target function `LLVMFuzzerTestOneInput` for the evolutionary fuzzer [libFuzzer](https://llvm.org/docs/LibFuzzer.html) to send input to.

Additional target functions will need to be designed to handle CLI input, JSON from `local.conf`, and also functions that aren't called externally.

We will also need to develop corpus of valid inputs to seed the evolutionary search.

*Note: this will not work on macOS with their default-supplied clang tools since the fuzzer isn't included by default. `brew install llvm` and proper path setting is required.*